### PR TITLE
Adds missing workflow permissions

### DIFF
--- a/.github/workflows/pr-linting.yml
+++ b/.github/workflows/pr-linting.yml
@@ -3,6 +3,9 @@ name: PR Linting
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-linting
 

--- a/.github/workflows/tag-on-version-change.yml
+++ b/.github/workflows/tag-on-version-change.yml
@@ -6,6 +6,10 @@ on:
       - main
     paths:
       - package.json
+
+permissions:
+  contents: write
+
 jobs:
   tag-npm-release:
     name: Tag NPM package releases


### PR DESCRIPTION
Potential fix for [https://github.com/zendamacf/hmpg/security/code-scanning/3](https://github.com/zendamacf/hmpg/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is not implicitly over-privileged. Since this workflow creates git tags, it needs write access to repository contents; a safe minimal set is:

- `contents: write`

Place this at the workflow root (after `on` and before `jobs`) so it applies to all jobs in this workflow unless overridden. This preserves existing behavior while making permissions explicit and least-privilege for the tagging operation. No imports, methods, or dependencies are needed; this is a YAML-only change in `.github/workflows/tag-on-version-change.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
