### PR TITLE
Upload code coverage to Codecov in PR tests

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,6 +2,9 @@ name: PR Tests
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-tests
@@ -59,7 +62,7 @@ jobs:
           fail_ci_if_error: true
 
       - name: Post coverage comment
-        if: success()
+        if: success() && github.event_name == 'pull_request'
         uses: davelosert/vitest-coverage-report-action@v2
         with:
           json-summary-path: coverage/coverage-summary.json

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -50,6 +50,14 @@ jobs:
       - name: Test
         run: npm run test:coverage
 
+      - name: Upload coverage to Codecov
+        if: success()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
+          fail_ci_if_error: true
+
       - name: Post coverage comment
         if: success()
         uses: davelosert/vitest-coverage-report-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: PR Tests
+name: Tests
 
 on:
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   test:
@@ -60,12 +59,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info
           fail_ci_if_error: true
-
-      - name: Post coverage comment
-        if: success() && github.event_name == 'pull_request'
-        uses: davelosert/vitest-coverage-report-action@v2
-        with:
-          json-summary-path: coverage/coverage-summary.json
 
   deploy-smoke:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hmpg
 
-[![Build Status](https://github.com/zendamacf/hmpg/workflows/PR%20Tests/badge.svg)](https://github.com/zendamacf/hmpg/actions/workflows/pr-tests.yml)
+[![Build Status](https://github.com/zendamacf/hmpg/workflows/Tests/badge.svg)](https://github.com/zendamacf/hmpg/actions/workflows/tests.yml)
 
 A new tab replacement page.
 [hmpg.kalopsia.dev](https://hmpg.kalopsia.dev)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     include: ['src/**/*.{test,spec,component.test}.{js,ts}'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'json-summary'],
+      reporter: ['text', 'json', 'json-summary', 'lcov'],
       reportsDirectory: 'coverage',
       include: ['src/lib/**/*.ts', 'src/routes/**/*.ts'],
       exclude: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Codecov coverage upload to the test workflow for pull requests and pushes to `main`, and renames the workflow from `pr-tests` to `tests`.

- Vitest emits `lcov` reports alongside existing JSON summaries.
- After tests pass, coverage is uploaded via `codecov/codecov-action@v5`.
- PR coverage comments are handled by Codecov (removed `vitest-coverage-report-action`).
- Workflow file renamed to `.github/workflows/tests.yml` with display name `Tests`.

## Setup required

Add a `CODECOV_TOKEN` repository secret with the upload token from [codecov.io](https://codecov.io). The workflow uses `fail_ci_if_error: true`, so uploads fail the job until this secret is configured.

## Test plan

- [x] `npm run test:coverage` generates `coverage/lcov.info`
- [ ] Workflow uploads coverage on PRs and `main` pushes after `CODECOV_TOKEN` is set
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30be3983-4adf-4a91-9ea9-306886442f60?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30be3983-4adf-4a91-9ea9-306886442f60&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

